### PR TITLE
Add optional SoC upper bound, inter-year SoC pinning, and dual price …

### DIFF
--- a/src/shipp/kernel_pyomo.py
+++ b/src/shipp/kernel_pyomo.py
@@ -26,7 +26,7 @@ from shipp.timeseries import TimeSeries
 from shipp.kernel import os_rule_based
 import warnings
 
-def solve_lp_pyomo(price_ts: TimeSeries, prod1: Production, prod2: Production, stor1: Storage, stor2: Storage, discount_rate: float, n_year: int, p_min: float, p_max: float, n: int, name_solver: str = 'mosek', fixed_cap: bool = False, dp_lim = None,     alpha_obj: float = DEFAULT_ALPHA_OBJ, verbose = False) -> OpSchedule:
+def solve_lp_pyomo(price_ts: TimeSeries, prod1: Production, prod2: Production, stor1: Storage, stor2: Storage, discount_rate: float, n_year: int, p_min: float, p_max: float, n: int, name_solver: str = 'mosek', fixed_cap: bool = False, dp_lim = None,     alpha_obj: float = DEFAULT_ALPHA_OBJ, verbose = False, return_duals: bool = False, soc_max1: float = 1.0, soc_max2: float = 1.0, e_start1: float = None) -> OpSchedule:
     """Build and solve an integrated dispatch NPV maximization with pyomo as a linear program.
 
     This function builds and solves the hybrid sizing and operation problem as a linear program. The objective is to minimize the Net Present Value of the plant. The optimization problem finds the optimal energy and power capacity of two storage systems and their optimal dispatch. In this function, the input for the power production represented by two Production objects. The problem can be constrained by a baseload power production constraint or a ramp limitation constraint.
@@ -165,7 +165,7 @@ def solve_lp_pyomo(price_ts: TimeSeries, prod1: Production, prod2: Production, s
         return model.p_vec1[i] >= -model.p_cap1
 
     def rule_e_max1(model, i):
-        return model.e_vec1[i] <= model.e_cap1
+        return model.e_vec1[i] <= model.e_cap1 * soc_max1
     
     def rule_e_min1(model, i):
         return model.e_vec1[i] >= model.e_cap1 * (1 - stor1.dod)
@@ -185,7 +185,7 @@ def solve_lp_pyomo(price_ts: TimeSeries, prod1: Production, prod2: Production, s
         return model.p_vec2[i] >= -model.p_cap2
 
     def rule_e_max2(model, i):
-        return model.e_vec2[i] <= model.e_cap2
+        return model.e_vec2[i] <= model.e_cap2 * soc_max2
     
     def rule_e_min2(model, i):
         return model.e_vec2[i] >= model.e_cap2*(1 - stor2.dod)
@@ -203,8 +203,12 @@ def solve_lp_pyomo(price_ts: TimeSeries, prod1: Production, prod2: Production, s
         return model.p_cur[i] <= power_res[i]
 
     # Constraint for each storage type
-    model.e_start_end1 =pyo.Constraint(expr = model.e_vec1[0]==model.e_vec1[n])
-    model.e_start_end2 =pyo.Constraint(expr = model.e_vec2[0]==model.e_vec2[n])
+    # Periodic constraint always holds: SoC(start) == SoC(end) for this year
+    model.e_start_end1 = pyo.Constraint(expr = model.e_vec1[0] == model.e_vec1[n])
+    # Inter-year continuity: if a fixed SoC fraction is supplied, pin the start level
+    if e_start1 is not None:
+        model.e_fix_start1 = pyo.Constraint(expr = model.e_vec1[0] == e_start1)
+    model.e_start_end2 = pyo.Constraint(expr = model.e_vec2[0] == model.e_vec2[n])
 
     model.e_model_charge1 = pyo.Constraint(model.vec_n, rule=rule_e_model_charge1)
     model.e_model_discharge1 = pyo.Constraint(model.vec_n, rule=rule_e_model_discharge1)
@@ -240,6 +244,12 @@ def solve_lp_pyomo(price_ts: TimeSeries, prod1: Production, prod2: Production, s
     model.p_cur_lim = pyo.Constraint(model.vec_n, rule=rule_p_cur_lim)
 
     # Solve problem
+    # Gap D: declare dual Suffix BEFORE solve so the solver populates shadow prices
+    if return_duals:
+        model.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+        model.rc   = pyo.Suffix(direction=pyo.Suffix.IMPORT)   # reduced costs for e_cap1 cross-check
+
+
     if verbose:
         results = pyo.SolverFactory(name_solver).solve(model, tee = True)
         model.display()
@@ -324,6 +334,33 @@ def solve_lp_pyomo(price_ts: TimeSeries, prod1: Production, prod2: Production, s
         os_res.time = results.solver[0]['Time']
 
     os_res.results = results
+
+    # Gap D: extract dual prices and attach to os_res
+    # dual_e_min1[i] = shadow price of  e_vec1[i] >= e_cap1*(1-dod)
+    #                = dRevenue / d(lower_SoC_bound_i)
+    # Outer loop gradient: dDeg/dDoD = -e_cap1 * dot(subgrad_combined, dual_e_min1)
+    os_res.dual_prices = None
+    if return_duals:
+        try:
+            dual_e_min1     = np.array([model.dual.get(model.e_min1[i],              0.0) for i in range(n)])
+            dual_e_max1     = np.array([model.dual.get(model.e_max1[i],              0.0) for i in range(n)])
+            dual_charge1    = np.array([model.dual.get(model.e_model_charge1[i],     0.0) for i in range(n)])
+            dual_discharge1 = np.array([model.dual.get(model.e_model_discharge1[i],  0.0) for i in range(n)])
+            rc_e_cap1       = float(model.rc.get(model.e_cap1, 0.0))
+            os_res.dual_prices = {
+                "dual_e_min1":     dual_e_min1,      # PRIMARY for chain rule
+                "dual_e_max1":     dual_e_max1,      # upper SoC bound
+                "dual_charge1":    dual_charge1,     # dynamics (charging active)
+                "dual_discharge1": dual_discharge1,  # dynamics (discharging active)
+                "dual_energy1":    dual_charge1 + dual_discharge1,  # net dynamics
+                "e_cap1":          float(pyo.value(model.e_cap1)),  # for scaling
+                "rc_e_cap1":       rc_e_cap1,        # reduced cost = dObj/de_cap1 (cross-check)
+            }
+        except Exception as exc:
+            warnings.warn(f"Gap D dual extraction failed: {exc}", RuntimeWarning)
+            os_res.dual_prices = None
+
+    os_res.soc_final = pyo.value(model.e_vec1[n])
 
     return os_res
 


### PR DESCRIPTION
These are the SHIPP-side changes required by my MSc thesis on battery
degradation modelling for hybrid wind-battery plants. They add three optional
arguments to `solve_lp_pyomo`; each defaults to the current behaviour, so
existing callers are unaffected.

**`soc_max1` / `soc_max2`** (default `1.0`)
Scales the energy upper bound to `e_cap * soc_max`. Together with the existing
`dod` parameter on the lower bound, this gives a two-sided state-of-charge
operating window. Restricting the window is one of the main levers a degradation-
aware operator has, and in this work it reduces annual capacity fade by around
10% at no revenue cost.

**`e_start1`** (default `None`)
Pins the initial state of charge. The periodicity constraint already ties start
to end, but not to any particular level, so each year's LP is free to choose its
own anchor. When simulating capacity fade year by year, that makes consecutive
years incomparable. Pinning the anchor at a constant fraction of the degraded
capacity isolates the fade being measured. Also adds `os_res.soc_final` so the
caller can read the closing level without re-reading the trajectory.

**`return_duals`** (default `False`)
Declares the Pyomo `dual` and `rc` suffixes before the solve and collects the
shadow prices into `os_res.dual_prices`. The dual on the lower state-of-charge
bound is the marginal value of stored energy per timestep; combined with the
degradation sub-gradient it forms the outer-loop gradient used in this thesis.
Extraction is wrapped in try/except and warns rather than failing.

Based on `feature_degradation`, so on the pre-1.2.1 signature. Happy to
re-express these through the `options` dictionary introduced in 577aa45.